### PR TITLE
Sync config/service on FreeBSD

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -25,7 +25,7 @@ define openvpn::service (
       }
     }
     'FreeBSD': {
-      $service_name = "openvpn_${title}"
+      $service_name = $title
       $service_provider = 'freebsd'
 
       file { "/usr/local/etc/rc.d/${service_name}":

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'openvpn::config' do
+  let(:title) { 'test' }
+  let(:facts) do
+    {
+      osfamily: osfamily
+    }
+  end
+  let(:params) do
+    {
+      role: 'server',
+      topology: 'subnet',
+      server_network: '10.0.0.0',
+      server_netmask: '255.0.0.0'
+    }
+  end
+
+  context 'on Debian' do
+    let(:osfamily) { 'Debian' }
+
+    it { is_expected.to contain_concat('/etc/openvpn/test.conf') }
+    it { is_expected.to contain_openvpn__service('test') }
+  end
+
+  context 'on FreeBSD' do
+    let(:osfamily) { 'FreeBSD' }
+
+    it { is_expected.to contain_concat('/usr/local/etc/openvpn/test.conf') }
+    it { is_expected.to contain_openvpn__service('test') }
+  end
+end

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'openvpn::service' do
+  let(:title) { 'test' }
+  let(:facts) do
+    {
+      osfamily: osfamily
+    }
+  end
+
+  context 'on Debian' do
+    let(:osfamily) { 'Debian' }
+
+    it { is_expected.to contain_service('openvpn-test') }
+  end
+
+  context 'on FreeBSD' do
+    let(:osfamily) { 'FreeBSD' }
+
+    it { is_expected.to contain_service('test') }
+  end
+end


### PR DESCRIPTION
The FreeBSD openvpn init script assumes that the service name is the
same as the config name.  By using a different name for the service
(`openvpn_foo`) and the configuration file (`foo.conf`), we must provide
an additional variable in `rc.conf.d/openvpn_foo`, `rc.conf.local` or
`rc.conf` (the first one start exists).

~~~
openvpn_foo_configfile=/usr/local/etc/openvpn/foo.conf
~~~

This file is managed by the service resource from Puppet that does not
offer an opportunity to define such a variable at the right place in a
convenient way, so switch back to not prefixing the service name with
`openvpn_`.